### PR TITLE
smaller bug fix regarding options `--web.listen-address` and `--insecure` + git tag

### DIFF
--- a/prometheus_fzj_weather_exporter/main.py
+++ b/prometheus_fzj_weather_exporter/main.py
@@ -46,15 +46,15 @@ def main():
 def get_parsed_args():
     parser = argparse.ArgumentParser(
         description='Set up the Prometheus exporter (connection ports)')
-    mutual_group = parser.add_mutually_exclusive_group()
-    mutual_group.add_argument(
+    group = parser.add_argument_group()
+    group.add_argument(
         '-w', '--web.listen-address',
         type=str,
         dest='listenaddress',
         help='Address and port to expose metrics and web interface. Default: ":9840"\n'
                 'To listen on all interfaces, omit the IP. ":<port>"`\n'\
                 'To listen on a specific IP: <address>:<port>')
-    mutual_group.add_argument(
+    group.add_argument(
         '-i', '--insecure',
         dest='insecure',
         action='store_true',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='prometheus_fzj_weather_exporter',
-    version='1.1.0',
+    version='1.1.1',
     description='prometheus exporter for weather data from FZJ',
     author='Oskar Druska',
     author_email='o.druska@fz-juelich.de',


### PR DESCRIPTION
Fixes a bug, which prevented the user from skipping the SSL validation of the website **and** specify a custom IP-address.
In addition it sets up the SerVer to 1.1.1 and adds the corresponding git tag.